### PR TITLE
Refactor serializers and update test file paths

### DIFF
--- a/PCAxis.Serializers/CsvSerializer.cs
+++ b/PCAxis.Serializers/CsvSerializer.cs
@@ -138,7 +138,7 @@ namespace PCAxis.Paxiom
         {
             wr.Write('"');
             wr.Write(value);
-            wr.WriteLine('"');
+            wr.Write('"');
         }
 
         protected string GetLabel(Variable variable)
@@ -179,7 +179,7 @@ namespace PCAxis.Paxiom
             if (this.IncludeTitle)
             {
                 WriteStringValue(wr, Util.GetModelTitle(_model));
-                wr.WriteLine();
+                wr.WriteLine("");
             }
         }
 

--- a/PCAxis.Serializers/HtmlSerializer.cs
+++ b/PCAxis.Serializers/HtmlSerializer.cs
@@ -243,7 +243,7 @@ namespace PCAxis.Serializers
                     wr.WriteLine("<tr>");
                     wr.Write(@"<th scope=""row"">");
 
-                    wr.Write(values[i].Text);
+                    wr.Write(GetLabel(values[i]));
                     wr.WriteLine("</th>");
                     _fmt = new DataFormatter(model);
 

--- a/PCAxis.Serializers/Xlsx2Serializer.cs
+++ b/PCAxis.Serializers/Xlsx2Serializer.cs
@@ -2,22 +2,13 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection.Emit;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 using ClosedXML.Excel;
 
-using DocumentFormat.OpenXml.EMMA;
-using DocumentFormat.OpenXml.Office2016.Excel;
-using DocumentFormat.OpenXml.Spreadsheet;
-
-using Parquet.Rows;
-
 using PCAxis.Paxiom;
 using PCAxis.Paxiom.Extensions;
 using PCAxis.Serializers.Excel;
-using PCAxis.Serializers.JsonStat2.Model;
 
 using Value = PCAxis.Paxiom.Value;
 
@@ -758,7 +749,7 @@ namespace PCAxis.Serializers
             string notes;
             for (int valueIndex = 0; valueIndex < variable.Values.Count; valueIndex++)
             {
-                text = variable.Values[valueIndex].Text;
+                text = GetLabel(variable.Values[valueIndex]);
                 if (variable.Values[valueIndex].HasNotes())
                 {
                     notes = variable.Values[valueIndex].Notes.GetAllNotes();
@@ -841,7 +832,7 @@ namespace PCAxis.Serializers
                 SetCell(
                     sheet.Cell(row, column),
                     CellContentType.Stub,
-                    val.Text,
+                    GetLabel(val),
                     c => c.Style.Font.Bold = true
                 );
 
@@ -922,6 +913,21 @@ namespace PCAxis.Serializers
 
             fmt.InformationLevel = InformationLevelType.AllInformation;
             return fmt;
+        }
+
+        private string GetLabel(Value value)
+        {
+            switch (ValueLablesDisplay)
+            {
+                case LablePreference.Code:
+                    return value.Code;
+                case LablePreference.Text:
+                    return value.Text;
+                case LablePreference.BothCodeAndText:
+                    return value.Code + " " + value.Text;
+                default:
+                    return value.Text;
+            }
         }
     }
 }

--- a/UnitTests/Csv/CsvSerializerTests.cs
+++ b/UnitTests/Csv/CsvSerializerTests.cs
@@ -9,6 +9,7 @@ using PCAxis.Paxiom;
 namespace PCAxis.Serializers.Tests.Csv
 {
     [TestClass]
+    [DeploymentItem("TestFiles/PR0101B3.px")]
     public class CsvSerializerTests
     {
         [TestMethod]
@@ -40,7 +41,7 @@ namespace PCAxis.Serializers.Tests.Csv
         {
             var serializer = new CsvSerializer();
             var helper = new UnitTests.Helper();
-            var model = helper.GetSelectAllModel("../../../TestFiles/PR0101B3.px");
+            var model = helper.GetSelectAllModel("PR0101B3.px");
             var path = "test.csv";
 
             serializer.Serialize(model, path);
@@ -54,7 +55,7 @@ namespace PCAxis.Serializers.Tests.Csv
         {
             var serializer = new CsvSerializer();
             var helper = new UnitTests.Helper();
-            var model = helper.GetSelectAllModel("../../../TestFiles/PR0101B3.px");
+            var model = helper.GetSelectAllModel("TestFiles/PR0101B3.px");
             var stream = new MemoryStream();
 
             serializer.Serialize(model, stream);
@@ -86,7 +87,7 @@ namespace PCAxis.Serializers.Tests.Csv
             var serializer = new CsvSerializer();
             serializer.IncludeTitle = true;
             var helper = new UnitTests.Helper();
-            var model = helper.GetSelectAllModel("../../../TestFiles/PR0101B3.px");
+            var model = helper.GetSelectAllModel("PR0101B3.px");
             var stream = new MemoryStream();
             var writer = new StreamWriter(stream, Encoding.UTF8);
 


### PR DESCRIPTION
Misc fixes:
- Modified `CsvSerializer` to avoid new lines in `WriteStringValue` method. 
- Updated `HtmlSerializer` and `Xlsx2Serializer` to use `GetLabel` method to fix if code, text or both should be displayed. 
- Fixed unit test in `CsvSerializerTests` that used PX files.