### PR TITLE
Adjustment of metaid feature, including a bugfix

### DIFF
--- a/PCAxis.Serializers/Util/Metaid/Link.cs
+++ b/PCAxis.Serializers/Util/Metaid/Link.cs
@@ -25,5 +25,10 @@
         /// What type of information is the link to: about-statistics, statistics-homepage, definition-classification, definition-value ,,,
         /// </summary>
         public string Relation { get; set; }
+
+        /// <summary>
+        /// MetaId that was the source for this Link  
+        /// </summary>
+        public string MetaId { get; set; }
     }
 }

--- a/PCAxis.Serializers/Util/Metaid/LinkTemplate.cs
+++ b/PCAxis.Serializers/Util/Metaid/LinkTemplate.cs
@@ -3,6 +3,7 @@ using System.Configuration;
 
 using PCAxis.Serializers.Util.MetaId;
 
+
 namespace PCAxis.Serializers.Util.Metaid
 {
     /// <summary>
@@ -61,15 +62,32 @@ namespace PCAxis.Serializers.Util.Metaid
         /// <param name="textParams"></param>
         /// <param name="linkParams"></param>
         /// <returns></returns>
-        public Link GetFormattedLink(string[] textParams, string[] linkParams)
+        public Link GetFormattedLink(string[] textParams, string[] linkParams, string metaId)
         {
             Link link = new Link();
             link.Relation = this.LinkRelation;
             link.Type = this.LinkType;
-
-            link.Url = String.Format(this.LinkUrlFormat, linkParams);
-            link.Label = String.Format(this.LinkTextFormat, textParams);
+            link.Url = FormatText(this.LinkUrlFormat, linkParams);
+            link.Label = FormatText(this.LinkTextFormat, textParams);
+            link.MetaId = metaId;
             return link;
+        }
+
+
+        private static string FormatText(string text, string[] formatParams)
+        {
+            if (String.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+            try
+            {
+                return String.Format(text, formatParams);
+            }
+            catch (Exception e)
+            {
+                return e.Message;
+            }
         }
     }
 }

--- a/PCAxis.Serializers/Util/Metaid/MetaIdResolverStatic.cs
+++ b/PCAxis.Serializers/Util/Metaid/MetaIdResolverStatic.cs
@@ -27,7 +27,7 @@ namespace PCAxis.Serializers.Util.MetaId
         /// <summary>
         /// Character that separates the systems within a META-ID
         /// </summary>
-        private static readonly char[] _systemSeparator = { ',', ' ' };
+        public static readonly char[] _systemSeparator = { ',', ' ' };
 
         /// <summary>
         /// Character that separates the parameters within a system META-ID
@@ -142,13 +142,13 @@ namespace PCAxis.Serializers.Util.MetaId
                 {
                     if (!template.Match(metaId))
                     {
-                        break;
+                        continue;
                     }
 
                     string rawParamsString = metaId.Replace(template.MetaSysId, "");
                     string[] linkParams = rawParamsString.Split(_paramSeparator, StringSplitOptions.RemoveEmptyEntries);
 
-                    myOut.Add(template.GetFormattedLink(textParams, linkParams));
+                    myOut.Add(template.GetFormattedLink(textParams, linkParams, metaId));
 
                 }
             }

--- a/UnitTests/Util/Metaid/UnitTest1.cs
+++ b/UnitTests/Util/Metaid/UnitTest1.cs
@@ -9,11 +9,8 @@ namespace UnitTests.Util.Metaid
     [TestClass]
     public class UnitTest1
     {
-
-
         public UnitTest1()
         {
-
         }
 
         [TestMethod]
@@ -111,16 +108,64 @@ namespace UnitTests.Util.Metaid
         public void TestMulti()
         {
             // both comma and space as separators
-            string metaid_raw = "urn:ssb:classification:klass:1 , urn:ssb:classification:klass:2 urn:ssb:classification:klass:3 ";
+            string metaid_raw = "urn:ssb:classification:klass:1 ,urn:ssb:conceptvariable:vardok:2 urn:ssb:classification:klass:3 ";
             string expectedUrl_0 = "https://www.ssb.no/en/klass/klassifikasjoner/1";
-            string expectedUrl_1 = "https://www.ssb.no/en/klass/klassifikasjoner/2";
+            string expectedUrl_1 = "https://www.ssb.no/a/metadata/conceptvariable/vardok/2/en";
             string expectedUrl_2 = "https://www.ssb.no/en/klass/klassifikasjoner/3";
+
+            string expectedMataid_2 = "urn:ssb:classification:klass:3";
 
             List<Link> links = MetaIdResolverStatic.GetVariableLinks(metaid_raw, "en", "region");
             Assert.AreEqual(3, links.Count);
             Assert.AreEqual(expectedUrl_0, links[0].Url);
             Assert.AreEqual(expectedUrl_1, links[1].Url);
             Assert.AreEqual(expectedUrl_2, links[2].Url);
+            Assert.AreEqual(expectedMataid_2, links[2].MetaId);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Util/Metaid/metaid.config")]
+        public void TestNoLabel()
+        {
+            string metaid_raw = "NO_LABEL:1";
+            string expectedUrl = "https://www.ssb.no/en/nice-document1";
+            string expectedLabel = "";
+
+
+            List<Link> links = MetaIdResolverStatic.GetTableLinks(metaid_raw, "en");
+            Assert.AreEqual(1, links.Count);
+            Assert.AreEqual(expectedUrl, links[0].Url);
+            Assert.AreEqual(expectedLabel, links[0].Label);
+        }
+
+        [TestMethod]
+        [DeploymentItem("Util/Metaid/metaid.config")]
+        public void TestAnyUrl()
+        {
+            // possible but is it a good idea?
+            string metaid_raw = "ANY_URL://www.ssb.no/en/nice-document2";
+            string expectedUrl = "https://www.ssb.no/en/nice-document2";
+            string expectedLabel = "";
+
+            List<Link> links = MetaIdResolverStatic.GetTableLinks(metaid_raw, "en");
+            Assert.AreEqual(1, links.Count);
+            Assert.AreEqual(expectedUrl, links[0].Url);
+            Assert.AreEqual(expectedLabel, links[0].Label);
+        }
+
+
+        [TestMethod]
+        [DeploymentItem("Util/Metaid/metaid.config")]
+        public void TestTooFewParams()
+        {
+            // exception text is passed when config or metaid dont fit.
+            // throwing an exception seems to much 
+            string metaid_raw = "urn:ssb:contextvariable:common:3";
+            string expectedUrl = "Index (zero based) must be greater than or equal to zero and less than the size of the argument list.";
+
+            List<Link> links = MetaIdResolverStatic.GetValueLinks(metaid_raw, "en", "region", "some value");
+            Assert.AreEqual(1, links.Count);
+            Assert.AreEqual(expectedUrl, links[0].Url);
 
         }
     }

--- a/UnitTests/Util/Metaid/metaid.config
+++ b/UnitTests/Util/Metaid/metaid.config
@@ -10,7 +10,19 @@
          <link pxLang="no" labelStringFormat="Om statistikken" urlStringFormat="https://www.ssb.no/{0}#om-statistikken" />
          <link pxLang="en" labelStringFormat="About the statistics" urlStringFormat="https://www.ssb.no/en/{0}#om-statistikken" />
       </relationalGroup>
-    </metaSystem> 
+    </metaSystem>
+    <metaSystem id="NO_LABEL">
+      <relationalGroup relation="test-no-label" type="text/html">
+        <link pxLang="no" labelStringFormat="" urlStringFormat="https://www.ssb.no/nice-document{0}" />
+        <link pxLang="en" labelStringFormat="" urlStringFormat="https://www.ssb.no/en/nice-document{0}" />
+      </relationalGroup>
+    </metaSystem>
+    <metaSystem id="ANY_URL">
+      <relationalGroup relation="any-url" type="text/html">
+        <link pxLang="no" labelStringFormat="" urlStringFormat="https:{0}" />
+        <link pxLang="en" labelStringFormat="" urlStringFormat="https:{0}" />
+      </relationalGroup>
+    </metaSystem>
   </onTable>
   <onVariable>
     <metaSystem id="urn:ssb:classification:klass">


### PR DESCRIPTION
Bug fix: break; -> continue;  Bug occured when a meta-id field reference multiple systems.
Added: source MetaId to the generated Links (for the Mapper in pxwebapi) 
error catching  so an error in number of params in a metaid does not stop the table
made systemSeparator public since the Mapper in pxwebapi use it. 
and added more tests