### PR TITLE
Update CsvSerializer to write contents instead of matrix PXWEB2-736

### DIFF
--- a/PCAxis.Serializers/CsvSerializer.cs
+++ b/PCAxis.Serializers/CsvSerializer.cs
@@ -215,7 +215,7 @@ namespace PCAxis.Paxiom
             {
                 // All parameters are in the Stub
                 wr.Write(this._delimiter);
-                WriteStringValue(wr, _model.Meta.Matrix);
+                WriteStringValue(wr, _model.Meta.Contents);
                 wr.WriteLine();
             }
         }


### PR DESCRIPTION
Using `Contents` instead of `Matrix` as column title if all variables are in the `Stub`