### PR TITLE
Update PCAxis.Core package to version 1.2.6

### DIFF
--- a/PCAxis.Serializers/PCAxis.Serializers.csproj
+++ b/PCAxis.Serializers/PCAxis.Serializers.csproj
@@ -28,7 +28,7 @@
 
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Parquet.Net" Version="4.25.0" />
-    <PackageReference Include="PCAxis.Core" Version="1.2.5" />
+    <PackageReference Include="PCAxis.Core" Version="1.2.6" />
     <PackageReference Include="PCAxis.Metadata" Version="1.0.3" />
     <PackageReference Include="PCAxis.Query" Version="1.0.9" />
     <PackageReference Include="ClosedXML" Version="0.97.0" />

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -17,7 +17,6 @@
 
     <PackageReference Include="Parquet.Net" Version="4.25.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="PCAxis.Core" Version="1.2.5" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Updated the `PCAxis.Core` package version from `1.2.5` to `1.2.6` in both the `PCAxis.Serializers.csproj` and `UnitTests.csproj` files.