### PR TITLE
metaid support for files with labels on the form "<metaid urn> <label text>"

### DIFF
--- a/PCAxis.Serializers/PCAxis.Serializers.csproj
+++ b/PCAxis.Serializers/PCAxis.Serializers.csproj
@@ -54,4 +54,18 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+  
+<ItemGroup>
+  <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+    <_Parameter1>UnitTests</_Parameter1>
+  </AssemblyAttribute>
+</ItemGroup>
+
+<ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
+</ItemGroup>
+
+  
 </Project>

--- a/PCAxis.Serializers/Util/Metaid/FileGetter.cs
+++ b/PCAxis.Serializers/Util/Metaid/FileGetter.cs
@@ -15,16 +15,16 @@ namespace PCAxis.Serializers.Util.MetaId
         private static readonly log4net.ILog _logger = log4net.LogManager.GetLogger(typeof(FileGetter));
 
 
-        XDocument IFileGetter.ReadConfig(string configFile)
+        XDocument IFileGetter.ReadConfig(string configurationFile)
         {
 
-            string configurationFile = configFile ?? DefaultConfigFilename;
+            string configFile = configurationFile ?? DefaultConfigFilename;
 
             //It is ok to not use metaid
-            if (!File.Exists(configurationFile))
+            if (!File.Exists(configFile))
             {
-                var fullPath = Path.GetFullPath(configurationFile);
-                if (configurationFile.Equals(DefaultConfigFilename))
+                var fullPath = Path.GetFullPath(configFile);
+                if (configFile.Equals(DefaultConfigFilename))
                 {
                     _logger.WarnFormat("Metaid configuration file '{0}' does not exist in the folder where the dlls are. So any metaids will not be replaced.", fullPath);
                     return null;
@@ -37,7 +37,7 @@ namespace PCAxis.Serializers.Util.MetaId
                 }
             }
 
-            return XDocument.Load(configurationFile);
+            return XDocument.Load(configFile);
         }
 
         Dictionary<string, string> IFileGetter.ReadLabelsfile(string labelsFilePath)

--- a/PCAxis.Serializers/Util/Metaid/FileGetter.cs
+++ b/PCAxis.Serializers/Util/Metaid/FileGetter.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+namespace PCAxis.Serializers.Util.MetaId
+{
+    internal class FileGetter : IFileGetter
+    {
+
+        const string DefaultConfigFilename = "metaid.config";
+        /// <summary>
+        /// Logging to Log4Net
+        /// </summary>
+        private static readonly log4net.ILog _logger = log4net.LogManager.GetLogger(typeof(FileGetter));
+
+
+        XDocument IFileGetter.ReadConfig(string configFile)
+        {
+
+            string configurationFile = configFile ?? DefaultConfigFilename;
+
+            //It is ok to not use metaid
+            if (!File.Exists(configurationFile))
+            {
+                var fullPath = Path.GetFullPath(configurationFile);
+                if (configurationFile.Equals(DefaultConfigFilename))
+                {
+                    _logger.WarnFormat("Metaid configuration file '{0}' does not exist in the folder where the dlls are. So any metaids will not be replaced.", fullPath);
+                    return null;
+                }
+                else
+                {
+                    string errMess = $"Metaid configuration file  '{fullPath}' not found.";
+                    _logger.Error(errMess);
+                    throw new FileNotFoundException(errMess);
+                }
+            }
+
+            return XDocument.Load(configurationFile);
+        }
+
+        Dictionary<string, string> IFileGetter.ReadLabelsfile(string labelsFilePath)
+        {
+            Dictionary<string, string> myOut = new Dictionary<string, string>();
+
+            if (string.IsNullOrEmpty(labelsFilePath))
+            {
+                return myOut;
+            }
+
+            if (!File.Exists(labelsFilePath))
+            {
+                var fullPath = Path.GetFullPath(labelsFilePath);
+                string errMess = $"Labelfile  '{fullPath}' not found.";
+                _logger.Error(errMess);
+                throw new FileNotFoundException(errMess);
+            }
+
+
+            char[] keySeparator = { ' ' };
+
+            foreach (var line in File.ReadLines(labelsFilePath))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                var parts = line.Split(keySeparator, 2, StringSplitOptions.RemoveEmptyEntries);
+
+                if (parts.Length != 2)
+                {
+                    Console.Error.WriteLine($"Ignoring bad line: '{line}'");
+                    continue;
+                }
+
+                myOut[parts[0]] = parts[1];
+            }
+
+            return myOut;
+        }
+    }
+}

--- a/PCAxis.Serializers/Util/Metaid/IFileGetter.cs
+++ b/PCAxis.Serializers/Util/Metaid/IFileGetter.cs
@@ -5,7 +5,7 @@ namespace PCAxis.Serializers.Util.MetaId
 {
     internal interface IFileGetter
     {
-        Dictionary<string, string> ReadLabelsfile(string filepath);
+        Dictionary<string, string> ReadLabelsfile(string labelsFilePath);
 
         XDocument ReadConfig(string configurationFile);
     }

--- a/PCAxis.Serializers/Util/Metaid/IFileGetter.cs
+++ b/PCAxis.Serializers/Util/Metaid/IFileGetter.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Xml.Linq;
+
+namespace PCAxis.Serializers.Util.MetaId
+{
+    internal interface IFileGetter
+    {
+        Dictionary<string, string> ReadLabelsfile(string filepath);
+
+        XDocument ReadConfig(string configurationFile);
+    }
+}

--- a/PCAxis.Serializers/Util/Metaid/LinkTemplate.cs
+++ b/PCAxis.Serializers/Util/Metaid/LinkTemplate.cs
@@ -1,10 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
 
-using PCAxis.Serializers.Util.MetaId;
-
-
-namespace PCAxis.Serializers.Util.Metaid
+namespace PCAxis.Serializers.Util.MetaId
 {
     /// <summary>
     /// Class with template for a link
@@ -13,7 +11,7 @@ namespace PCAxis.Serializers.Util.Metaid
     {
         private readonly string _metaSysId;
 
-        public LinkTemplate(string metaSysId, string textFormat, string linkFormat, string linkType, string linkRelation)
+        public LinkTemplate(string metaSysId, string textFormat, Dictionary<string, string> labelsFile, string linkFormat, string linkType, string linkRelation)
         {
             if (string.IsNullOrWhiteSpace(metaSysId))
             {
@@ -26,6 +24,7 @@ namespace PCAxis.Serializers.Util.Metaid
             }
 
             this.LinkTextFormat = textFormat;
+            this.labelsFile = labelsFile;
             this.LinkUrlFormat = linkFormat;
             this.LinkType = linkType;
             this.LinkRelation = linkRelation;
@@ -42,6 +41,11 @@ namespace PCAxis.Serializers.Util.Metaid
         /// Format of the link text
         /// </summary>
         public string LinkTextFormat { get; }
+
+        /// <summary>
+        /// Dictionary of custom labels from file.
+        /// </summary>
+        private readonly Dictionary<string, string> labelsFile;
 
         /// <summary>
         /// Format of the link (URL)
@@ -68,7 +72,15 @@ namespace PCAxis.Serializers.Util.Metaid
             link.Relation = this.LinkRelation;
             link.Type = this.LinkType;
             link.Url = FormatText(this.LinkUrlFormat, linkParams);
-            link.Label = FormatText(this.LinkTextFormat, textParams);
+
+            if (labelsFile.ContainsKey(metaId))
+            {
+                link.Label = labelsFile[metaId];
+            }
+            else
+            {
+                link.Label = FormatText(this.LinkTextFormat, textParams);
+            }
             link.MetaId = metaId;
             return link;
         }

--- a/PCAxis.Serializers/Util/Metaid/LinkTemplatesHolder.cs
+++ b/PCAxis.Serializers/Util/Metaid/LinkTemplatesHolder.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace PCAxis.Serializers.Util.Metaid
+namespace PCAxis.Serializers.Util.MetaId
 {
     enum AttachmentLevel { onTable, onVariable, onValue }
 

--- a/PCAxis.Serializers/Util/Metaid/MetaIdResolver.cs
+++ b/PCAxis.Serializers/Util/Metaid/MetaIdResolver.cs
@@ -62,7 +62,7 @@ namespace PCAxis.Serializers.Util.MetaId
                 return;
             }
             //for "manual" labels files.
-            _LabelFilesFolder = this._xdoc?.Root?.Attribute("labelFilesFolder")?.Value ?? AppContext.BaseDirectory; ;
+            _LabelFilesFolder = this._xdoc.Root?.Attribute("labelFilesFolder")?.Value ?? AppContext.BaseDirectory;
 
             // Table-level
             LoadConfigurationSection(AttachmentLevel.onTable, this.holder, filereader);

--- a/PCAxis.Serializers/Util/Metaid/MetaIdResolver.cs
+++ b/PCAxis.Serializers/Util/Metaid/MetaIdResolver.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+
+namespace PCAxis.Serializers.Util.MetaId
+{
+    /// <summary>
+    /// Class that encapsulates a metaid.config file containing link-definitions to metadata systems,
+    /// and has methods that resolves a "raw" meta-id string to Links.
+    /// The non-static version, which may become dependency injected in the future. 
+    /// </summary>
+    internal class MetaIdResolver
+    {
+        #region Private fields
+
+        /// <summary>
+        /// Configuration file (LINQ to XML)
+        /// </summary>
+        private readonly XDocument _xdoc;
+
+        /// <summary>
+        /// Logging to Log4Net
+        /// </summary>
+        private static readonly log4net.ILog _logger = log4net.LogManager.GetLogger(typeof(MetaIdResolver));
+
+        /// <summary>
+        /// Character that separates the systems within a META-ID
+        /// </summary>
+        public static readonly char[] _systemSeparator = { ',', ' ' };
+
+        /// <summary>
+        /// Character that separates the parameters within a system META-ID
+        /// </summary>
+        private static readonly char[] _paramSeparator = { ':' };
+
+        /// <summary>
+        /// Holds all data loaded from config, reshuffled so using it easy.
+        /// </summary>
+        private readonly LinkTemplatesHolder holder;
+
+        /// <summary>
+        /// Get the root folder for labels files.
+        /// May be given onthe metaid-element (the xml-root), if so it is used, else the dll (AppContext.BaseDirectory) folder is used.
+        /// </summary>
+        private readonly string _LabelFilesFolder;
+
+        #endregion
+
+        //Used by the static version
+        internal MetaIdResolver() : this(null, new FileGetter()) { }
+
+        //now, only used directly by tests. 
+        internal MetaIdResolver(string configurationFile, IFileGetter filereader)
+        {
+            this.holder = new LinkTemplatesHolder();
+
+            this._xdoc = filereader.ReadConfig(configurationFile);
+            if (this._xdoc == null)
+            {
+                return;
+            }
+            //for "manual" labels files.
+            _LabelFilesFolder = this._xdoc?.Root?.Attribute("labelFilesFolder")?.Value ?? AppContext.BaseDirectory; ;
+
+            // Table-level
+            LoadConfigurationSection(AttachmentLevel.onTable, this.holder, filereader);
+
+            // Variable-level
+            LoadConfigurationSection(AttachmentLevel.onVariable, this.holder, filereader);
+
+            // Value-level
+            LoadConfigurationSection(AttachmentLevel.onValue, this.holder, filereader);
+
+        }
+
+        /// <summary>
+        /// Load sub section of the configuration file
+        /// </summary>
+        /// <param name="attachmentLevel">Name of the section</param>
+        /// <param name="holder">To store section data in</param>
+        /// <returns></returns>
+        private void LoadConfigurationSection(AttachmentLevel attachmentLevel, LinkTemplatesHolder holder, IFileGetter filereader)
+        {
+            string sectionName = attachmentLevel.ToString();
+
+            var metaSystems = this._xdoc
+                .Root?
+                .Element(sectionName)?
+                .Elements("metaSystem");
+
+            if (metaSystems == null)
+                return;
+
+            foreach (var sysNode in metaSystems)
+            {
+                string sysId = (string)sysNode.Attribute("id");
+                if (string.IsNullOrEmpty(sysId))
+                {
+                    continue;
+                }
+
+                foreach (var relationalGroup in sysNode.Elements("relationalGroup"))
+                {
+                    string linkType = (string)relationalGroup.Attribute("type");
+                    string linkRelation = (string)relationalGroup.Attribute("relation");
+
+                    foreach (var linkNode in relationalGroup.Elements("link"))
+                    {
+                        string pxLang = (string)linkNode.Attribute("pxLang");
+                        if (string.IsNullOrEmpty(pxLang))
+                        {
+                            continue;
+                        }
+
+                        string labelsFilename = GetLabelsFilename(linkNode.Attribute("labelsFile"));
+
+                        Dictionary<string, string> labelsFile = filereader.ReadLabelsfile(labelsFilename);
+
+                        string labelStringFormat = (string)linkNode.Attribute("labelStringFormat");
+
+                        string urlStringFormat = (string)linkNode.Attribute("urlStringFormat");
+
+                        LinkTemplate template = new LinkTemplate(
+                            sysId,
+                            labelStringFormat,
+                            labelsFile,
+                            urlStringFormat,
+                            linkType,
+                            linkRelation);
+
+                        holder.Add(attachmentLevel, pxLang, template);
+                    }
+                }
+            }
+        }
+
+        #region Labels file
+
+
+        private string GetLabelsFilename(XAttribute labelsFileAttr)
+        {
+            string filename = labelsFileAttr?.Value;
+            if (string.IsNullOrEmpty(filename))
+            {
+                return "";
+            }
+            return Path.Combine(this._LabelFilesFolder, filename);
+        }
+
+
+        #endregion
+
+        #region Link creation
+
+        private static List<Link> GetLinks(string metaIdList, List<LinkTemplate> templates, string[] textParams)
+        {
+            List<Link> myOut = new List<Link>();
+
+            if (templates.Count == 0)
+            {
+                return myOut;
+            }
+
+            string[] metaIds = metaIdList.Split(_systemSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+            foreach (string metaId in metaIds)
+            {
+                foreach (LinkTemplate template in templates)
+                {
+                    if (!template.Match(metaId))
+                    {
+                        continue;
+                    }
+
+                    string rawParamsString = metaId.Replace(template.MetaSysId, "");
+
+                    string[] linkParams = rawParamsString.Split(_paramSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+                    myOut.Add(template.GetFormattedLink(textParams, linkParams, metaId));
+                }
+            }
+
+            return myOut;
+        }
+
+        #endregion
+
+        #region IMetaIdProvider
+
+        public List<Link> GetTableLinks(string metaIdField, string language)
+        {
+            return GetLinks(metaIdField, this.holder.GetTemplates(AttachmentLevel.onTable, language), Array.Empty<string>());
+        }
+
+        public List<Link> GetVariableLinks(string metaIdField, string language, string variableLabel)
+        {
+            return GetLinks(metaIdField, this.holder.GetTemplates(AttachmentLevel.onVariable, language), new[] { variableLabel });
+        }
+
+        public List<Link> GetValueLinks(string metaIdField, string language, string variableLabel, string valueLabel)
+        {
+            return GetLinks(metaIdField, this.holder.GetTemplates(AttachmentLevel.onValue, language), new[] { variableLabel, valueLabel });
+        }
+
+        #endregion
+    }
+}

--- a/PCAxis.Serializers/Util/Metaid/MetaIdResolverStatic.cs
+++ b/PCAxis.Serializers/Util/Metaid/MetaIdResolverStatic.cs
@@ -1,23 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Xml;
-
-using PCAxis.Serializers.Util.Metaid;
+﻿using System.Collections.Generic;
 
 namespace PCAxis.Serializers.Util.MetaId
 {
     /// <summary>
-    /// Class that encapsulates a metaid.config file containing link-definitions to metadata systems, and has methodsw that resolves a "raw" meta-id string to Links.
+    /// Class that encapsulates a metaid.config file containing link-definitions to metadata systems,
+    /// and has methods that resolves a "raw" meta-id string to Links.
+    /// This is a static wrapper.
     /// </summary>
     public static class MetaIdResolverStatic
     {
-
-        #region "Private fields"
-
-        /// <summary>
-        /// Configuration file
-        /// </summary>
-        private static XmlDocument _xdoc;
 
         /// <summary>
         /// Logging to Log4Net
@@ -34,151 +25,23 @@ namespace PCAxis.Serializers.Util.MetaId
         /// </summary>
         private static readonly char[] _paramSeparator = { ':' };
 
-        /// <summary>
-        /// Holds all data loaded from config, reshuffled so using it easy.
-        /// </summary>
-        private static readonly LinkTemplatesHolder holder = LoadConfiguration("metaid.config");
 
-        #endregion
-
-
-        /// <summary>
-        /// Load metadata.config file
-        /// </summary>
-        /// <param name="configurationFile">Path to the configuration file</param>
-        /// <returns>True if the configuration file was successfully loaded, else false</returns>
-        private static LinkTemplatesHolder LoadConfiguration(string configurationFile)
-        {
-            //It is ok to not use metaid
-            if (!System.IO.File.Exists(configurationFile))
-            {
-                _logger.WarnFormat("Metaid configuration file '{0}' does not exist in the folder where the dlls are ...", configurationFile);
-                return new LinkTemplatesHolder();
-            }
-
-            _xdoc = new XmlDocument();
-            _xdoc.Load(configurationFile);
-
-            LinkTemplatesHolder myOut = new LinkTemplatesHolder();
-
-            // Table-level
-            LoadConfigurationSection(AttachmentLevel.onTable, myOut);
-
-            // Variable-level
-            LoadConfigurationSection(AttachmentLevel.onVariable, myOut);
-
-            // Value-level
-            LoadConfigurationSection(AttachmentLevel.onValue, myOut);
-
-            return myOut;
-        }
-
-        /// <summary>
-        /// Load sub section of the configuration file
-        /// </summary>
-        /// <param name="section">Name of the section</param>
-        /// <param name="dictionary">Dictionary to store section data in</param>
-        /// <returns></returns>
-        private static void LoadConfigurationSection(AttachmentLevel attachmentLevel, LinkTemplatesHolder holder)
-        {
-            // Find all metaSystem nodes in section
-            string section = attachmentLevel.ToString();
-
-            string xpath = "/metaId/" + section + "/metaSystem";
-            XmlNodeList xmlnodes = _xdoc.SelectNodes(xpath);
-
-            foreach (XmlNode sysNode in xmlnodes)
-            {
-                string sysId = sysNode.Attributes["id"].Value;
-
-                // Find all language nodes for the system
-                xpath = ".//relationalGroup";
-                XmlNodeList relationalGroupNodes = sysNode.SelectNodes(xpath);
-
-                foreach (XmlNode relationalGroupNode in relationalGroupNodes)
-                {
-                    string linkType = relationalGroupNode.Attributes["type"].Value;
-                    string linkRelation = relationalGroupNode.Attributes["relation"].Value;
-
-                    // Find all language nodes for the system
-                    xpath = ".//link";
-                    XmlNodeList linkNodes = relationalGroupNode.SelectNodes(xpath);
-
-                    foreach (XmlNode linkNode in linkNodes)
-                    {
-                        string pxLang = linkNode.Attributes["pxLang"].Value;
-                        string labelStringFormat = linkNode.Attributes["labelStringFormat"].Value;
-                        string urlStringFormat = linkNode.Attributes["urlStringFormat"].Value;
-
-                        LinkTemplate temp = new LinkTemplate(sysId, labelStringFormat, urlStringFormat, linkType, linkRelation);
-                        holder.Add(attachmentLevel, pxLang, temp);
-                    }
-                }
-            }
-        }
-
-
-        /// <summary>
-        /// Create links
-        /// </summary>
-        /// <param name="metaIdList">META-ID one or more</param>
-        /// <param name="templates">templates for Language and attachmentlevel</param>
-        /// <param name="textParams">0,1 or 2 text parameters, depending on attachmentleve</param>
-        /// <returns></returns>
-        private static List<Link> GetLinks(string metaIdList, List<LinkTemplate> templates, string[] textParams)
-        {
-            List<Link> myOut = new List<Link>();
-
-            if (templates.Count == 0)
-            {
-                return myOut;
-            }
-
-            string[] metaIds = metaIdList.Split(_systemSeparator, StringSplitOptions.RemoveEmptyEntries);
-
-            foreach (string metaId in metaIds)
-            {
-                foreach (LinkTemplate template in templates)
-                {
-                    if (!template.Match(metaId))
-                    {
-                        continue;
-                    }
-
-                    string rawParamsString = metaId.Replace(template.MetaSysId, "");
-                    string[] linkParams = rawParamsString.Split(_paramSeparator, StringSplitOptions.RemoveEmptyEntries);
-
-                    myOut.Add(template.GetFormattedLink(textParams, linkParams, metaId));
-
-                }
-            }
-
-            return myOut;
-        }
-
-
-
-        #region "Implementation of IMetaIdProvider"
-
+        private static readonly MetaIdResolver Instance = new MetaIdResolver();
 
         public static List<Link> GetTableLinks(string metaIdField, string language)
         {
-            string[] textParams = new string[] { };
-            return GetLinks(metaIdField, holder.GetTemplates(AttachmentLevel.onTable, language), textParams);
+            return Instance.GetTableLinks(metaIdField, language);
         }
 
         public static List<Link> GetVariableLinks(string metaIdField, string language, string variableLabel)
         {
-            string[] textParams = new string[] { variableLabel };
-            return GetLinks(metaIdField, holder.GetTemplates(AttachmentLevel.onVariable, language), textParams);
+            return Instance.GetVariableLinks(metaIdField, language, variableLabel);
         }
 
         public static List<Link> GetValueLinks(string metaIdField, string language, string variableLabel, string valueLabel)
         {
-            string[] textParams = new string[] { variableLabel, valueLabel };
-            return GetLinks(metaIdField, holder.GetTemplates(AttachmentLevel.onValue, language), textParams);
+            return Instance.GetValueLinks(metaIdField, language, variableLabel, valueLabel);
         }
-        #endregion
 
     }
 }

--- a/UnitTests/TestFiles/metaid.config
+++ b/UnitTests/TestFiles/metaid.config
@@ -26,13 +26,13 @@
   </onTable>
   <onVariable>
     <metaSystem id="urn:ssb:classification:klass">
-       <relationalGroup relation="definition-classification" type="text/html">   
+       <relationalGroup relation="definitions" type="text/html">   
          <link pxLang="no" labelStringFormat="Klassifikasjon for {0}." urlStringFormat="https://www.ssb.no/klass/klassifikasjoner/{0}" />
          <link pxLang="en" labelStringFormat="Classification for {0}." urlStringFormat="https://www.ssb.no/en/klass/klassifikasjoner/{0}" />
        </relationalGroup>  
     </metaSystem>
     <metaSystem id="urn:ssb:conceptvariable:vardok">
-      <relationalGroup relation="definition-classification" type="text/html">   
+      <relationalGroup relation="definitions" type="text/html">   
          <link pxLang="no" labelStringFormat="Definisjon av {0}." urlStringFormat="https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/nb" />
          <link pxLang="en" labelStringFormat="Definition of {0}." urlStringFormat="https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/en" />
       </relationalGroup>
@@ -40,13 +40,13 @@
   </onVariable>
   <onValue>
     <metaSystem id="urn:ssb:conceptvariable:vardok">
-      <relationalGroup relation="definition-value" type="text/html">
+      <relationalGroup relation="definitions" type="text/html">
         <link pxLang="no" labelStringFormat="Definisjon av {1} for vaiabel {0}." urlStringFormat="https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/nb" />
         <link pxLang="en" labelStringFormat="Definition of {1} for vaiable {0}." urlStringFormat="https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/en" />
       </relationalGroup>
     </metaSystem>
     <metaSystem id="urn:ssb:contextvariable:common">
-      <relationalGroup relation="definition-value" type="text/html">
+      <relationalGroup relation="definitions" type="text/html">
         <link pxLang="no" labelStringFormat="Definisjon av {1} (Kostra)." urlStringFormat="https://www.ssb.no/kompis/statbank/?id={0}&amp;ver={1}&amp;val={2}" />
         <link pxLang="en" labelStringFormat="Definition of {1} (Kostra)." urlStringFormat="https://www.ssb.no/kompis/statbank/?id={0}&amp;ver={1}&amp;val={2}" />
       </relationalGroup>  

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
     <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
     <PackageReference Include="coverlet.collector" Version="8.0.1">
@@ -31,7 +32,7 @@
     <None Update="TestFiles\*.px">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Update="Util/Metaid/metaid.config">
+    <None Update="TestFiles\metaid*.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/UnitTests/Util/Metaid/MetaIdResolverStaticTests.cs
+++ b/UnitTests/Util/Metaid/MetaIdResolverStaticTests.cs
@@ -7,9 +7,9 @@ using PCAxis.Serializers.Util.MetaId;
 namespace UnitTests.Util.Metaid
 {
     [TestClass]
-    public class UnitTest1
+    public class MetaIdResolverStaticTests
     {
-        public UnitTest1()
+        public MetaIdResolverStaticTests()
         {
         }
 

--- a/UnitTests/Util/Metaid/MetaIdResolverTests.cs
+++ b/UnitTests/Util/Metaid/MetaIdResolverTests.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Linq;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Moq;
+
+using PCAxis.Serializers.Util.MetaId;
+
+namespace UnitTests.Util.Metaid
+{
+    [TestClass]
+    public class MetaIdResolverTests
+    {
+
+        private Mock<IFileGetter> _readerMock;
+
+        private readonly string _config_1 = "<?xml version=\"1.0\"?>\n<metaId labelFilesFolder=\"\">\n  <onTable>\n    <metaSystem id=\"STATISTICS\">\n      <relationalGroup relation=\"statistics-homepage\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"Statistikkens hjemmeside\" urlStringFormat=\"https://www.ssb.no/{0}\" />\n        <link pxLang=\"en\" labelStringFormat=\"Statistics homepage\" urlStringFormat=\"https://www.ssb.no/en/{0}\" />\n      </relationalGroup>\n      <relationalGroup relation=\"about-statistics\" type=\"text/html\">\n         <link pxLang=\"no\" labelStringFormat=\"Om statistikken\" urlStringFormat=\"https://www.ssb.no/{0}#om-statistikken\" />\n         <link pxLang=\"en\" labelStringFormat=\"About the statistics\" urlStringFormat=\"https://www.ssb.no/en/{0}#om-statistikken\" />\n      </relationalGroup>\n    </metaSystem>\n    <metaSystem id=\"NO_LABEL\">\n      <relationalGroup relation=\"test-no-label\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"\" urlStringFormat=\"https://www.ssb.no/nice-document{0}\" />\n        <link pxLang=\"en\" labelStringFormat=\"\" urlStringFormat=\"https://www.ssb.no/en/nice-document{0}\" />\n      </relationalGroup>\n    </metaSystem>\n    <metaSystem id=\"ANY_URL\">\n      <relationalGroup relation=\"any-url\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"\" urlStringFormat=\"https:{0}\" />\n        <link pxLang=\"en\" labelStringFormat=\"\" urlStringFormat=\"https:{0}\" />\n      </relationalGroup>\n    </metaSystem>\n  </onTable>\n  <onVariable>\n    <metaSystem id=\"urn:ssb:classification:klass\">\n       <relationalGroup relation=\"definitions\" type=\"text/html\">   \n         <link pxLang=\"no\" labelStringFormat=\"Klassifikasjon for {0}.\" labelsFile=\"Testfiles/metaid_labelFilesFolder/class_no.txt\" urlStringFormat=\"https://www.ssb.no/klass/klassifikasjoner/{0}\" />\n         <link pxLang=\"en\" labelStringFormat=\"Classification for {0}.\" labelsFile=\"Testfiles/metaid_labelFilesFolder/class_en.txt\" urlStringFormat=\"https://www.ssb.no/en/klass/klassifikasjoner/{0}\" />\n       </relationalGroup>  \n    </metaSystem>\n    <metaSystem id=\"urn:ssb:conceptvariable:vardok\">\n      <relationalGroup relation=\"definitions\" type=\"text/html\">   \n         <link pxLang=\"no\" labelStringFormat=\"Definisjon av {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/nb\" />\n         <link pxLang=\"en\" labelStringFormat=\"Definition of {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/en\" />\n      </relationalGroup>\n    </metaSystem>\n  </onVariable>\n  <onValue>\n    <metaSystem id=\"urn:ssb:conceptvariable:vardok\">\n      <relationalGroup relation=\"definitions\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"Definisjon av {1} for vaiabel {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/nb\" />\n        <link pxLang=\"en\" labelStringFormat=\"Definition of {1} for vaiable {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/en\" />\n      </relationalGroup>\n    </metaSystem>\n    <metaSystem id=\"urn:ssb:contextvariable:common\">\n      <relationalGroup relation=\"definitions\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"Definisjon av {1} (Kostra).\" urlStringFormat=\"https://www.ssb.no/kompis/statbank/?id={0}&amp;ver={1}&amp;val={2}\" />\n        <link pxLang=\"en\" labelStringFormat=\"Definition of {1} (Kostra).\" urlStringFormat=\"https://www.ssb.no/kompis/statbank/?id={0}&amp;ver={1}&amp;val={2}\" />\n      </relationalGroup>  \n    </metaSystem>\n  </onValue>\n</metaId>\n";
+
+        //private readonly string _class_en = "urn:ssb:classification:klass:2 From file, Standard for gender\nurn:ssb:classification:klass:5 Standard for PRODCOM codes";
+
+
+        private readonly Dictionary<string, string> _class_en = new Dictionary<string, string>
+        {
+            ["urn:ssb:classification:klass:2"] = "From file, Standard for gender",
+            ["urn:ssb:classification:klass:5"] = "Standard for PRODCOM codes"
+        };
+
+        private readonly Dictionary<string, string> _class_no = new Dictionary<string, string>
+        {
+            ["urn:ssb:classification:klass:2"] = "Standard for kjønn",
+            ["urn:ssb:classification:klass:5"] = "Standard for PRODCOM koder"
+        };
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _readerMock = new Mock<IFileGetter>(MockBehavior.Strict);
+            _readerMock.Setup(x => x.ReadConfig(It.IsAny<string>()))
+                .Returns((string fileName) =>
+                {
+
+                    if (fileName.EndsWith("metaid.config", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return XDocument.Parse(_config_1);
+                    }
+
+                    throw new FileNotFoundException(fileName);
+
+                });
+
+            _readerMock.Setup(x => x.ReadLabelsfile(It.IsAny<string>()))
+                .Returns((string fileName) =>
+                {
+                    if (String.IsNullOrEmpty(fileName))
+                    {
+                        return new Dictionary<string, string>();
+                    }
+                    if (fileName.EndsWith("class_en.txt", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return _class_en;
+                    }
+                    if (fileName.EndsWith("class_no.txt", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return _class_no;
+                    }
+
+                    throw new FileNotFoundException(fileName);
+
+                });
+        }
+
+
+        [TestMethod]
+        public void ReadsMetaIdConfig()
+        {
+            // Act
+            var resolver = new MetaIdResolver("metaid.config", _readerMock.Object);
+
+            // Assert
+            _readerMock.Verify(x => x.ReadConfig("metaid.config"), Times.Once);
+        }
+
+
+        [TestMethod]
+        public void TestLabelFromFile()
+        {
+            var resolver = new MetaIdResolver("metaid.config", _readerMock.Object);
+
+            string metaid_raw = "urn:ssb:classification:klass:2";
+            string expectedLinkText = "From file, Standard for gender";
+            List<Link> links = resolver.GetVariableLinks(metaid_raw, "en", "Override me");
+            Assert.AreEqual(expectedLinkText, links[0].Label);
+        }
+
+        [TestMethod]
+        public void TestLabelNotFromFile()
+        {
+            var resolver = new MetaIdResolver("metaid.config", _readerMock.Object);
+
+            string metaid_raw = "urn:ssb:classification:klass:1";
+            string expectedLinkText = "Classification for variablelabel.";
+            List<Link> links = resolver.GetVariableLinks(metaid_raw, "en", "variablelabel");
+            Assert.AreEqual(expectedLinkText, links[0].Label);
+
+        }
+
+        [TestMethod]
+        public void Ctor_WhenConfigCannotBeRead_ThrowsException()
+        {
+            // Act & Assert
+            Assert.Throws<FileNotFoundException>(
+                () => new MetaIdResolver("no_such_config.xml", _readerMock.Object)
+            );
+        }
+
+    }
+
+
+
+
+
+}

--- a/UnitTests/Util/Metaid/MetaIdResolverTests.cs
+++ b/UnitTests/Util/Metaid/MetaIdResolverTests.cs
@@ -19,8 +19,13 @@ namespace UnitTests.Util.Metaid
 
         private readonly string _config_1 = "<?xml version=\"1.0\"?>\n<metaId labelFilesFolder=\"\">\n  <onTable>\n    <metaSystem id=\"STATISTICS\">\n      <relationalGroup relation=\"statistics-homepage\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"Statistikkens hjemmeside\" urlStringFormat=\"https://www.ssb.no/{0}\" />\n        <link pxLang=\"en\" labelStringFormat=\"Statistics homepage\" urlStringFormat=\"https://www.ssb.no/en/{0}\" />\n      </relationalGroup>\n      <relationalGroup relation=\"about-statistics\" type=\"text/html\">\n         <link pxLang=\"no\" labelStringFormat=\"Om statistikken\" urlStringFormat=\"https://www.ssb.no/{0}#om-statistikken\" />\n         <link pxLang=\"en\" labelStringFormat=\"About the statistics\" urlStringFormat=\"https://www.ssb.no/en/{0}#om-statistikken\" />\n      </relationalGroup>\n    </metaSystem>\n    <metaSystem id=\"NO_LABEL\">\n      <relationalGroup relation=\"test-no-label\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"\" urlStringFormat=\"https://www.ssb.no/nice-document{0}\" />\n        <link pxLang=\"en\" labelStringFormat=\"\" urlStringFormat=\"https://www.ssb.no/en/nice-document{0}\" />\n      </relationalGroup>\n    </metaSystem>\n    <metaSystem id=\"ANY_URL\">\n      <relationalGroup relation=\"any-url\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"\" urlStringFormat=\"https:{0}\" />\n        <link pxLang=\"en\" labelStringFormat=\"\" urlStringFormat=\"https:{0}\" />\n      </relationalGroup>\n    </metaSystem>\n  </onTable>\n  <onVariable>\n    <metaSystem id=\"urn:ssb:classification:klass\">\n       <relationalGroup relation=\"definitions\" type=\"text/html\">   \n         <link pxLang=\"no\" labelStringFormat=\"Klassifikasjon for {0}.\" labelsFile=\"Testfiles/metaid_labelFilesFolder/class_no.txt\" urlStringFormat=\"https://www.ssb.no/klass/klassifikasjoner/{0}\" />\n         <link pxLang=\"en\" labelStringFormat=\"Classification for {0}.\" labelsFile=\"Testfiles/metaid_labelFilesFolder/class_en.txt\" urlStringFormat=\"https://www.ssb.no/en/klass/klassifikasjoner/{0}\" />\n       </relationalGroup>  \n    </metaSystem>\n    <metaSystem id=\"urn:ssb:conceptvariable:vardok\">\n      <relationalGroup relation=\"definitions\" type=\"text/html\">   \n         <link pxLang=\"no\" labelStringFormat=\"Definisjon av {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/nb\" />\n         <link pxLang=\"en\" labelStringFormat=\"Definition of {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/en\" />\n      </relationalGroup>\n    </metaSystem>\n  </onVariable>\n  <onValue>\n    <metaSystem id=\"urn:ssb:conceptvariable:vardok\">\n      <relationalGroup relation=\"definitions\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"Definisjon av {1} for vaiabel {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/nb\" />\n        <link pxLang=\"en\" labelStringFormat=\"Definition of {1} for vaiable {0}.\" urlStringFormat=\"https://www.ssb.no/a/metadata/conceptvariable/vardok/{0}/en\" />\n      </relationalGroup>\n    </metaSystem>\n    <metaSystem id=\"urn:ssb:contextvariable:common\">\n      <relationalGroup relation=\"definitions\" type=\"text/html\">\n        <link pxLang=\"no\" labelStringFormat=\"Definisjon av {1} (Kostra).\" urlStringFormat=\"https://www.ssb.no/kompis/statbank/?id={0}&amp;ver={1}&amp;val={2}\" />\n        <link pxLang=\"en\" labelStringFormat=\"Definition of {1} (Kostra).\" urlStringFormat=\"https://www.ssb.no/kompis/statbank/?id={0}&amp;ver={1}&amp;val={2}\" />\n      </relationalGroup>  \n    </metaSystem>\n  </onValue>\n</metaId>\n";
 
-        //private readonly string _class_en = "urn:ssb:classification:klass:2 From file, Standard for gender\nurn:ssb:classification:klass:5 Standard for PRODCOM codes";
+        private readonly string _config_labelsFolder = "<?xml version=\"1.0\"?>\n<metaId labelFilesFolder=\"MylabelFilesFolder\">\n  <onVariable>\n    <metaSystem id=\"urn:ssb:classification:klass\">\n       <relationalGroup relation=\"definitions\" type=\"text/html\">   \n         <link pxLang=\"en\" labelStringFormat=\"Classification for {0}.\" labelsFile=\"labels_folder_file_en.txt\" urlStringFormat=\"https://www.ssb.no/en/klass/klassifikasjoner/{0}\" />\n       </relationalGroup>  \n    </metaSystem>\n  </onVariable>\n</metaId>";
 
+        private readonly Dictionary<string, string> _labelsfolder_en = new Dictionary<string, string>
+        {
+            ["urn:ssb:classification:klass:2"] = "Using labelsFolder , Standard for gender",
+            ["urn:ssb:classification:klass:5"] = "Using labelsFolder ,Standard for PRODCOM codes"
+        };
 
         private readonly Dictionary<string, string> _class_en = new Dictionary<string, string>
         {
@@ -33,6 +38,7 @@ namespace UnitTests.Util.Metaid
             ["urn:ssb:classification:klass:2"] = "Standard for kjønn",
             ["urn:ssb:classification:klass:5"] = "Standard for PRODCOM koder"
         };
+
 
         [TestInitialize]
         public void TestInitialize()
@@ -47,6 +53,11 @@ namespace UnitTests.Util.Metaid
                         return XDocument.Parse(_config_1);
                     }
 
+                    if (fileName.EndsWith("metaid_labelsFolder.config", StringComparison.OrdinalIgnoreCase))
+                    {
+                        return XDocument.Parse(_config_labelsFolder);
+                    }
+
                     throw new FileNotFoundException(fileName);
 
                 });
@@ -58,6 +69,7 @@ namespace UnitTests.Util.Metaid
                     {
                         return new Dictionary<string, string>();
                     }
+
                     if (fileName.EndsWith("class_en.txt", StringComparison.OrdinalIgnoreCase))
                     {
                         return _class_en;
@@ -67,10 +79,22 @@ namespace UnitTests.Util.Metaid
                         return _class_no;
                     }
 
+                    if (fileName.Equals("MylabelFilesFolder" + Path.DirectorySeparatorChar + "labels_folder_file_en.txt") ||
+                        fileName.Equals("MylabelFilesFolder" + Path.AltDirectorySeparatorChar + "labels_folder_file_en.txt")
+                    )
+                    {
+                        return _labelsfolder_en;
+                    }
+
+
                     throw new FileNotFoundException(fileName);
 
                 });
         }
+
+
+
+
 
 
         [TestMethod]
@@ -106,6 +130,18 @@ namespace UnitTests.Util.Metaid
             Assert.AreEqual(expectedLinkText, links[0].Label);
 
         }
+
+
+        [TestMethod]
+        public void TestLabelFolder()
+        {
+            var resolver = new MetaIdResolver("metaid_labelsFolder.config", _readerMock.Object);
+            string metaid_raw = "urn:ssb:classification:klass:2";
+            string expectedLinkText = _labelsfolder_en[metaid_raw];
+            List<Link> links = resolver.GetVariableLinks(metaid_raw, "en", "Override me");
+            Assert.AreEqual(expectedLinkText, links[0].Label);
+        }
+
 
         [TestMethod]
         public void Ctor_WhenConfigCannotBeRead_ThrowsException()

--- a/UnitTests/Util/Metaid/UnitTest1.cs
+++ b/UnitTests/Util/Metaid/UnitTest1.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestOnTable()
         {
             string metaid_raw = "STATISTICS:aku";
@@ -34,7 +34,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestOnVaiable()
         {
 
@@ -42,7 +42,7 @@ namespace UnitTests.Util.Metaid
             string expectedUrl = "https://www.ssb.no/en/klass/klassifikasjoner/123";
             string expectedLinkText = "Classification for region.";
             string expectedType = "text/html";
-            string expectedRelation = "definition-classification";
+            string expectedRelation = "definitions";
 
             List<Link> links = MetaIdResolverStatic.GetVariableLinks(metaid_raw, "en", "region");
 
@@ -64,7 +64,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestOnValue()
         {
 
@@ -76,7 +76,7 @@ namespace UnitTests.Util.Metaid
             string expectedLinkText_no = "Definisjon av Oslo for vaiabel region.";
 
             string expectedType = "text/html";
-            string expectedRelation = "definition-value";
+            string expectedRelation = "definitions";
 
             List<Link> links = MetaIdResolverStatic.GetValueLinks(metaid_raw, "en", "region", "Oslo");
 
@@ -95,7 +95,7 @@ namespace UnitTests.Util.Metaid
 
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestMissing()
         {
             string metaid_raw = "missing:123";
@@ -104,7 +104,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestMulti()
         {
             // both comma and space as separators
@@ -124,7 +124,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestNoLabel()
         {
             string metaid_raw = "NO_LABEL:1";
@@ -139,7 +139,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestAnyUrl()
         {
             // possible but is it a good idea?
@@ -155,7 +155,7 @@ namespace UnitTests.Util.Metaid
 
 
         [TestMethod]
-        [DeploymentItem("Util/Metaid/metaid.config")]
+        [DeploymentItem("Testfiles/metaid.config")]
         public void TestTooFewParams()
         {
             // exception text is passed when config or metaid dont fit.

--- a/UnitTests/Util/Metaid/UnitTest1.cs
+++ b/UnitTests/Util/Metaid/UnitTest1.cs
@@ -14,7 +14,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestOnTable()
         {
             string metaid_raw = "STATISTICS:aku";
@@ -34,7 +34,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestOnVaiable()
         {
 
@@ -64,7 +64,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestOnValue()
         {
 
@@ -95,7 +95,7 @@ namespace UnitTests.Util.Metaid
 
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestMissing()
         {
             string metaid_raw = "missing:123";
@@ -104,7 +104,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestMulti()
         {
             // both comma and space as separators
@@ -124,7 +124,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestNoLabel()
         {
             string metaid_raw = "NO_LABEL:1";
@@ -139,7 +139,7 @@ namespace UnitTests.Util.Metaid
         }
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestAnyUrl()
         {
             // possible but is it a good idea?
@@ -155,7 +155,7 @@ namespace UnitTests.Util.Metaid
 
 
         [TestMethod]
-        [DeploymentItem("Testfiles/metaid.config")]
+        [DeploymentItem("TestFiles/metaid.config")]
         public void TestTooFewParams()
         {
             // exception text is passed when config or metaid dont fit.


### PR DESCRIPTION
Instead of constructing link labels from variable and value texts it is now possible to read them from file. The use case in when you have mutliple classifications on one variable like region. The files may be stored in a folder given as an attribute on the  root element <metaid> on in the same folder as the metaid.config file. 

To enable testing with different config.files, most of MetaIdResolverStatic.cs was moved to MetaIdResolver.cs
and the IFileGetter.cs and FileGetter.cs was introduced . 

Some of the internal files had PCAxis.Serializers.Util.Metaid  this is now PCAxis.Serializers.Util.MetaId
